### PR TITLE
Update ec2_alb_private_hostname.tf

### DIFF
--- a/ec2_alb_private_hostname.tf
+++ b/ec2_alb_private_hostname.tf
@@ -184,7 +184,7 @@ resource "aws_lb_listener_rule" "ec2_alb_private_hostname" {
 
   condition {
     source_ip {
-      values = var.source_ip
+      values = var.source_ips
     }
   }
 


### PR DESCRIPTION


Getting this error
│ Error: Reference to undeclared input variable
│ 
│   on .terraform/modules/ec2_alb_private_hostname/ec2_alb_private_hostname.tf line 187, in resource "aws_lb_listener_rule" "ec2_alb_private_hostname":
│  187:       values = var.source_ip
│ 
│ An input variable with the name "source_ip" has not been declared. Did you mean "source_ips"?

Fixed By adding source_ips